### PR TITLE
Use separate thread for serial handling to drastically reduce CPU usage

### DIFF
--- a/SCS/APP/main.py
+++ b/SCS/APP/main.py
@@ -8,7 +8,7 @@ import subprocess
 
 import SCS
 import mqtt2
-from asyncserial import Serial
+from serialhandler import SerialHandler
 
 import databaseAttuatori
 
@@ -54,7 +54,7 @@ lock_uartTX = asyncio.Lock()
 lock_refresh_Database = asyncio.Lock()
 
 
-ser = Serial(loop,
+ser = SerialHandler(
 		port='/dev/serial0', #Replace ttyS0 with ttyAM0 for Pi1,Pi2,Pi0
 		baudrate = 9600
 )

--- a/SCS/APP/serialhandler.py
+++ b/SCS/APP/serialhandler.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+from serial import Serial
+import asyncio
+import time
+import threading
+import queue
+
+class SerialHandler(object):
+    def __init__(self, port, baudrate=9600):
+        self.adict = {}
+
+        ser = Serial(
+            port=port,
+            baudrate=baudrate
+        )
+        self.adict['ser'] = ser
+        self.adict['rque'] = asyncio.Queue()
+        self.adict['loop'] = asyncio.get_event_loop()
+
+        print("Starting handlers..")
+        rt = threading.Thread(target=self._read)
+        rt.daemon = True
+        rt.start()
+
+    async def read(self):
+        return await self.adict['rque'].get()
+
+    def _read(self):
+        print("TREADER: ONLINE")
+        while True:
+            line = self.adict['ser'].read(1)
+            line += self.adict['ser'].read(self.adict['ser'].in_waiting)
+            print("<",line)
+            self.adict['loop'].create_task(self.adict['rque'].put(line))
+
+    async def write(self, data):
+        line = bytes(bytearray(data))
+        print(">",line)
+        self.adict['ser'].write(line)
+
+async def main():
+    s = SerialHandler('/dev/serial0',9600)
+    time.sleep(1)
+    print(await s.read())
+    while True:
+        line = await s.read()
+        print(line)
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
The ASYNC-ONLY implementation used right now continously opens and closes the serial port, creating a huge CPU hoverhead (100% CPU used on a Raspberry PI Zero 2 W)
By simply using a separate thread to manage the serial reads the program now uses almost 0% CPU, while still handling all the reads/writes correctly.
(I had this code working in my home for ~4 months, never had any issue)